### PR TITLE
Added sanity check for dropIndex

### DIFF
--- a/lrDragNDrop.js
+++ b/lrDragNDrop.js
@@ -150,6 +150,9 @@
                                     break;
                                 }
                             }
+                            if (dropIndex < 0) {
+                                dropIndex = 0;
+                            }
                         }
                         scope.$apply(function () {
                             collection.splice(dropIndex, 0, item);


### PR DESCRIPTION
When dropping first item on itself the drop position ends up to be -1, which moves the before-last position. Issue #6 
